### PR TITLE
feat(openapi): OpenAPI 3.x and /api/openapi.json (#2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Microservice based on [Reei-dp/fastapi-template](https://github.com/Reei-dp/fast
 
 **CI:** on push/PR to `dev`, GitHub Actions runs **ruff** (lint + format check), **pytest** with coverage, and **docker build** (`docker/Dockerfile`). Dev tools: `pip install -r requirements-dev.txt`.
 
+**OpenAPI 3.x:** `GET /api/openapi.json` — machine-readable spec (tags, `BearerAuth` security scheme). `GET /api/docs` serves Swagger UI (Basic auth placeholder in `src/main.py`).
+
 **Workflow:** one issue → one branch from `dev` → tests for that change → one PR into `dev`. Same policy for [`bots/auth_bot`](https://github.com/ZhuchkaTriplesix/ZhuchkaKeyboards_auth_bot). Details: [git-workflow.md](https://github.com/ZhuchkaTriplesix/ZhuchkaKeyboards/blob/main/docs/git-workflow.md) (section «`services/auth` и `bots/auth_bot`»).
 
 ### Auth API (summary)

--- a/src/configuration/app.py
+++ b/src/configuration/app.py
@@ -9,6 +9,7 @@ from starlette.middleware.cors import CORSMiddleware
 from src.auth.bootstrap import run_bootstrap
 from src.database.core import async_session_maker
 from src.database.dependencies import DbSession
+from src.openapi_config import OPENAPI_TAGS, apply_openapi
 from src.routers import Router
 
 logging.basicConfig(
@@ -37,9 +38,11 @@ class App:
             docs_url=None,
             redoc_url=None,
             openapi_url="/api/openapi.json",
+            openapi_tags=OPENAPI_TAGS,
             default_response_class=ORJSONResponse,
             lifespan=_lifespan,
         )
+        apply_openapi(self._app)
         self._app.add_middleware(
             middleware_class=CORSMiddleware,
             allow_origins=["*"],

--- a/src/openapi_config.py
+++ b/src/openapi_config.py
@@ -1,0 +1,56 @@
+"""OpenAPI 3.x metadata and custom schema (see /api/openapi.json)."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.openapi.utils import get_openapi
+
+OPENAPI_TAGS: list[dict[str, str]] = [
+    {"name": "health", "description": "Liveness and readiness probes."},
+    {
+        "name": "oauth",
+        "description": "OAuth2 token endpoint, revoke, OIDC discovery, JWKS.",
+    },
+    {"name": "oidc", "description": "OIDC discovery document and JWKS (same router as oauth)."},
+    {
+        "name": "admin",
+        "description": "Administrative API; requires Bearer JWT whose `scope` includes `admin`.",
+    },
+    {"name": "root", "description": "Template root routes (health under /api/root)."},
+]
+
+
+def apply_openapi(app: FastAPI) -> None:
+    """Attach a generator that produces OpenAPI 3.x JSON with shared metadata."""
+
+    def custom_openapi() -> dict:
+        if app.openapi_schema:
+            return app.openapi_schema
+        openapi_schema = get_openapi(
+            title=app.title,
+            version=app.version,
+            openapi_version=app.openapi_version,
+            description=app.description,
+            routes=app.routes,
+            tags=app.openapi_tags,
+        )
+        info = openapi_schema.setdefault("info", {})
+        info.setdefault("contact", {"name": "ZhuchkaKeyboards"})
+        info.setdefault("license", {"name": "MIT"})
+        components = openapi_schema.setdefault("components", {})
+        schemes = components.setdefault("securitySchemes", {})
+        schemes.setdefault(
+            "BearerAuth",
+            {
+                "type": "http",
+                "scheme": "bearer",
+                "bearerFormat": "JWT",
+                "description": (
+                    "OAuth2 access token (JWT). Admin APIs require `scope` containing `admin`."
+                ),
+            },
+        )
+        app.openapi_schema = openapi_schema
+        return app.openapi_schema
+
+    app.openapi = custom_openapi

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -1,0 +1,24 @@
+"""OpenAPI 3.x document at GET /api/openapi.json."""
+
+from starlette.testclient import TestClient
+
+from src.main import app
+
+
+def test_openapi_json_schema():
+    with TestClient(app) as client:
+        response = client.get("/api/openapi.json")
+    assert response.status_code == 200
+    assert response.headers.get("content-type", "").startswith("application/json")
+    body = response.json()
+    assert body["openapi"].startswith("3.")
+    assert body["info"]["title"] == "Zhuchka Auth"
+    assert body["info"]["version"] == "1.0.0"
+    paths = body["paths"]
+    assert "/oauth/token" in paths
+    assert "/.well-known/openid-configuration" in paths
+    assert "/api/v1/users" in paths
+    assert "BearerAuth" in body["components"]["securitySchemes"]
+    tags = {t["name"] for t in body.get("tags", [])}
+    assert "admin" in tags
+    assert "oauth" in tags


### PR DESCRIPTION
## Summary
- Centralized OpenAPI 3.x generation: tag descriptions, \info.contact\ / \info.license\, documented \BearerAuth\ security scheme.
- \GET /api/openapi.json\ unchanged in path; schema content is explicit and tested.

## Testing
- \pytest tests/test_openapi.py\ — OpenAPI version, key paths (\/oauth/token\, OIDC, admin users), \BearerAuth\.

Closes #2

Made with [Cursor](https://cursor.com)