### PR TITLE
feat(docker): run migrations on container start

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ cp config.ini.example config.ini
 
 3. Edit `config.ini` file according to your needs
 
+**Docker:** the app image runs **`alembic upgrade head`** on container start (before Granian/uvicorn), using the same DB URL as the app (`config.ini` `[POSTGRES]` or `DATABASE_URL` / `ALEMBIC_DATABASE_URL`). In Compose, point Postgres `IP` at the DB service name (e.g. `postgres`). To skip migrations, set **`SKIP_MIGRATIONS=1`**.
+
 ### Running (Development)
 
 #### Using Docker Compose:
@@ -134,6 +136,7 @@ ZhuchkaKeyboards_auth/
 ├── docker/
 │   ├── Dockerfile                # Production Dockerfile
 │   ├── Dockerfile.dev            # Development Dockerfile
+│   ├── docker-entrypoint.sh      # alembic upgrade head, then app
 │   ├── docker-compose.yml        # Production stack
 │   ├── docker-compose.dev.yml    # Development stack
 │   └── nginx/

--- a/config.ini.example
+++ b/config.ini.example
@@ -7,7 +7,8 @@ DATABASE = postgresql
 DRIVER = asyncpg
 DATABASE_NAME = your_database_name
 USERNAME = postgres
-PASSWORD = your_password  
+PASSWORD = your_password
+# Docker Compose: set to the Postgres service hostname (e.g. `postgres`), not `localhost`
 IP = localhost
 PORT = 5432
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,6 +31,11 @@ COPY --from=builder /root/.local /home/appuser/.local
 # Copy application code
 COPY --chown=appuser:appuser . .
 
+# Alembic expects alembic.ini on disk; sqlalchemy.url is overridden at runtime from config.ini (see env.py)
+COPY --chown=appuser:appuser alembic.ini.example ./alembic.ini
+
+RUN chmod +x /app/docker/docker-entrypoint.sh
+
 # Set environment variables
 ENV PATH=/home/appuser/.local/bin:$PATH \
     PYTHONUNBUFFERED=1 \
@@ -48,7 +53,7 @@ EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD python -c "import requests; requests.get('http://localhost:8000/api/root/health')" || exit 1
 
-# Run the application
-# Configuration is read from config.ini automatically
+# Migrations on start (docker-entrypoint.sh), then Granian via src/main.py
+ENTRYPOINT ["/app/docker/docker-entrypoint.sh"]
 CMD ["python", "src/main.py"]
 

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -24,6 +24,10 @@ RUN pip install --no-cache-dir \
 # Copy application code
 COPY . .
 
+COPY alembic.ini.example ./alembic.ini
+
+RUN chmod +x /app/docker/docker-entrypoint.sh
+
 # Set environment variables
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
@@ -32,8 +36,7 @@ ENV PYTHONUNBUFFERED=1 \
 # Expose ports (8000 for app, 5678 for debugger)
 EXPOSE 8000 5678
 
-# Run with hot-reload
-# Note: For development, using uvicorn directly with --reload
-# In production, config.ini values are used (see Dockerfile)
+# Migrations on start, then hot-reload server
+ENTRYPOINT ["/app/docker/docker-entrypoint.sh"]
 CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
 

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -14,8 +14,10 @@ services:
       - /app/__pycache__
       - ../config.ini:/app/config.ini:ro
     depends_on:
-      - postgres
-      - redis
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_started
     networks:
       - app-network
 
@@ -32,6 +34,11 @@ services:
       - postgres-dev-data:/var/lib/postgresql/data
     networks:
       - app-network
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
 
   redis:
     image: redis:7-alpine

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,8 +13,10 @@ services:
       - ../logs:/app/logs
       - ../config.ini:/app/config.ini:ro
     depends_on:
-      - postgres
-      - redis
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_started
     networks:
       - app-network
     healthcheck:

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+cd /app
+
+if [ "${SKIP_MIGRATIONS:-0}" = "1" ]; then
+  echo "SKIP_MIGRATIONS=1: skipping alembic upgrade head"
+else
+  echo "Running database migrations (alembic upgrade head)..."
+  alembic upgrade head
+fi
+
+exec "$@"

--- a/src/database/alembic/env.py
+++ b/src/database/alembic/env.py
@@ -18,6 +18,23 @@ config = context.config
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
+
+def _apply_database_url_override() -> None:
+    """Prefer DATABASE_URL / ALEMBIC_DATABASE_URL; else build from config.ini (same as the app)."""
+    url = os.environ.get("DATABASE_URL") or os.environ.get("ALEMBIC_DATABASE_URL")
+    if not url:
+        try:
+            from src.config import PostgresCfg
+
+            url = PostgresCfg().url
+        except Exception:
+            return
+    if url:
+        config.set_main_option("sqlalchemy.url", url)
+
+
+_apply_database_url_override()
+
 target_metadata = Base.metadata
 
 


### PR DESCRIPTION
## Summary
- **Entrypoint** \docker/docker-entrypoint.sh\: runs \lembic upgrade head\, then starts the app (Granian / uvicorn).
- **\SKIP_MIGRATIONS=1\** to bypass migrations (debug).
- **\lembic/env.py\**: DB URL from \DATABASE_URL\ / \ALEMBIC_DATABASE_URL\, or same as the app via \PostgresCfg()\ / \config.ini\.
- **Dockerfile** copies \lembic.ini.example\ → \lembic.ini\ in the image (URL overridden at runtime).
- **Compose**: app waits for **Postgres healthy**; dev stack adds a Postgres healthcheck.

## Testing
- \uff\, \pytest\ locally.

Made with [Cursor](https://cursor.com)