### PR TITLE
fix(orm): OAuthClient table oauth_client (CustomBase naming)

### DIFF
--- a/src/auth/db_models.py
+++ b/src/auth/db_models.py
@@ -77,6 +77,8 @@ class UserRole(Base):
 
 
 class OAuthClient(Base):
+    # CustomBase would resolve "OAuthClient" -> o_auth_client; DB table is oauth_client (see Alembic).
+    __tablename__ = "oauth_client"
     __repr_attrs__ = ("client_id",)
 
     id: Mapped[UUID] = mapped_column(Uuid(as_uuid=True), primary_key=True, default=uuid.uuid4)
@@ -99,6 +101,10 @@ class OAuthClient(Base):
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
 
+    refresh_tokens: Mapped[list[RefreshToken]] = relationship(
+        "RefreshToken", back_populates="client"
+    )
+
 
 class RefreshToken(Base):
     id: Mapped[UUID] = mapped_column(Uuid(as_uuid=True), primary_key=True, default=uuid.uuid4)
@@ -115,6 +121,8 @@ class RefreshToken(Base):
     replaced_by_id: Mapped[UUID | None] = mapped_column(
         Uuid(as_uuid=True), ForeignKey("refresh_token.id"), nullable=True
     )
+
+    client: Mapped[OAuthClient] = relationship("OAuthClient", back_populates="refresh_tokens")
 
 
 class LoginAudit(Base):

--- a/tests/test_db_models.py
+++ b/tests/test_db_models.py
@@ -1,6 +1,6 @@
 """Domain models align with Alembic migrations (issue #3)."""
 
-from src.auth.db_models import ExternalIdentity, LoginAudit, User
+from src.auth.db_models import ExternalIdentity, LoginAudit, OAuthClient, User
 
 
 def test_user_has_identity_kind_column():
@@ -15,3 +15,7 @@ def test_login_audit_has_login_method():
 
 def test_external_identity_table_name():
     assert ExternalIdentity.__table__.name == "external_identity"
+
+
+def test_oauth_client_table_name():
+    assert OAuthClient.__table__.name == "oauth_client"


### PR DESCRIPTION
## Problem

CustomBase resolves OAuthClient to table o_auth_client, but Alembic and FKs use oauth_client. PR #24 merged before this commit landed on the branch, so dev may still map OAuthClient to the wrong table.

## Changes

- Set __tablename__ = oauth_client on OAuthClient
- Restore RefreshToken.client / OAuthClient.refresh_tokens with back_populates
- Add test_oauth_client_table_name

Cherry-picked from commit 4cb8154.
