### PR TITLE
fix(auth): staff cannot use Telegram/Google federated login + [AUTH] docs

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -5,7 +5,26 @@ This guide covers different deployment methods for your FastAPI application.
 ## Table of Contents
 
 - [Docker Deployment](#docker-deployment)
+- [Auth service environment (`config.ini` `[AUTH]`)](#auth-service-environment-configini-auth)
 - [Production Checklist](#production-checklist)
+
+## Auth service environment (`config.ini` `[AUTH]`)
+
+OAuth/JWT and federated login are configured under the **`[AUTH]`** section (see `config.ini.example` in the repo).
+
+| Variable | Purpose |
+|----------|---------|
+| `ISSUER` | JWT `iss` claim; must match the public URL of this service (no trailing slash). |
+| `AUDIENCE` | Default JWT `aud` for API tokens. |
+| `ACCESS_TOKEN_MINUTES` / `REFRESH_TOKEN_DAYS` | Access and refresh lifetimes. |
+| `JWT_PRIVATE_KEY_PATH` | PEM path for RS256 signing; generated on first run if missing. |
+| `BOOTSTRAP_*` | Optional: create admin user + confidential OAuth client on startup (dev). |
+| `PASSWORD_GRANT_ENABLED` | Allow `grant_type=password` (typically for staff; not for public clients). |
+| `TELEGRAM_BOT_TOKEN` | @BotFather token; required for `POST /oauth/federated/telegram`. |
+| `GOOGLE_CLIENT_IDS` | Comma-separated Google OAuth **Web** client IDs; required for `POST /oauth/federated/google` (ID token audience check). |
+| `PUBLIC_OAUTH_CLIENT_ID` | Public browser client (no secret), e.g. `zhuchka-market-web`, used with federated and refresh flows. |
+
+For production, load secrets via your orchestrator (Kubernetes secrets, Docker secrets) and mount or inject `config.ini`; do not commit real tokens.
 
 ## Docker Deployment
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ All `/api/v1/*` routes require **Bearer** JWT with **`admin` scope**.
 
 **Bootstrap (dev):** set `[AUTH]` `BOOTSTRAP_ADMIN_EMAIL`, `BOOTSTRAP_ADMIN_PASSWORD`, and `BOOTSTRAP_CLIENT_SECRET` in `config.ini`. On startup the service creates roles, a confidential OAuth client (`BOOTSTRAP_CLIENT_ID`), and an admin user. RSA key for JWT is created under `var/jwt_private.pem` if `AUTH_JWT_PRIVATE_KEY_PEM` is not set.
 
-**Federated login (storefront):** bootstrap also creates a **public** OAuth client (`PUBLIC_OAUTH_CLIENT_ID`, default `zhuchka-market-web`) with no secret — use this `client_id` from browser apps. Set `TELEGRAM_BOT_TOKEN` (from @BotFather) and comma-separated `GOOGLE_CLIENT_IDS` (Google OAuth Web client ID(s)) to enable `POST /oauth/federated/*`.
+**Federated login (storefront):** bootstrap also creates a **public** OAuth client (`PUBLIC_OAUTH_CLIENT_ID`, default `zhuchka-market-web`) with no secret — use this `client_id` from browser apps. Set `TELEGRAM_BOT_TOKEN` (from @BotFather) and comma-separated `GOOGLE_CLIENT_IDS` (Google OAuth Web client ID(s)) to enable `POST /oauth/federated/*`. Users with `identity_kind=staff` **cannot** complete Telegram/Google login (HTTP 403 `access_denied`); they must use the operational password/MFA flow.
 
 **Migrations:** `alembic upgrade head` (from repo root with `alembic.ini` / `config.ini` configured). Chain: `20250323_0001` (users, roles, OAuth clients, refresh tokens, login audit) → `20250323_0002` (`users.identity_kind` `customer`/`staff`, `external_identity` for federated IdPs, `login_audit.login_method`). Requires PostgreSQL with `pgcrypto` or `gen_random_uuid()` (PostgreSQL 13+).
 

--- a/src/auth/federated_login.py
+++ b/src/auth/federated_login.py
@@ -21,6 +21,12 @@ def _synthetic_telegram_email(telegram_id: int) -> str:
     return f"tg.{telegram_id}@telegram.federated.zhuchka"
 
 
+def _ensure_customer_for_federated_login(user: User) -> None:
+    """Staff accounts must use org-issued credentials, not Telegram/Google (see docs/microservices/01-auth.md)."""
+    if user.identity_kind == "staff":
+        raise ValueError("staff_federation_denied")
+
+
 async def login_with_telegram(
     session: AsyncSession,
     *,
@@ -58,6 +64,7 @@ async def login_with_telegram(
     ext = r.scalar_one_or_none()
     if ext and ext.user:
         user = ext.user
+        _ensure_customer_for_federated_login(user)
     else:
         email = _synthetic_telegram_email(tid)
         ur = await session.execute(
@@ -66,6 +73,7 @@ async def login_with_telegram(
         existing = ur.scalar_one_or_none()
         if existing:
             user = existing
+            _ensure_customer_for_federated_login(user)
             session.add(
                 ExternalIdentity(
                     user_id=user.id,
@@ -145,6 +153,7 @@ async def login_with_google(
     ext = r.scalar_one_or_none()
     if ext and ext.user:
         user = ext.user
+        _ensure_customer_for_federated_login(user)
     else:
         ur = await session.execute(
             select(User).options(selectinload(User.roles)).where(User.email == email)
@@ -152,6 +161,7 @@ async def login_with_google(
         existing = ur.scalar_one_or_none()
         if existing:
             user = existing
+            _ensure_customer_for_federated_login(user)
             session.add(
                 ExternalIdentity(
                     user_id=user.id,

--- a/src/routers/oauth/federated_router.py
+++ b/src/routers/oauth/federated_router.py
@@ -75,6 +75,12 @@ async def oauth_federated_telegram(
             return oauth_error(401, "invalid_client", "Use the public storefront client_id")
         if code == "invalid_grant":
             return oauth_error(400, "invalid_grant", "Telegram signature or payload invalid")
+        if code == "staff_federation_denied":
+            return oauth_error(
+                403,
+                "access_denied",
+                "Staff accounts cannot sign in via Telegram or Google; use the operational login.",
+            )
         return oauth_error(400, "invalid_grant", code)
     await session.commit()
     return JSONResponse(content=out)
@@ -109,6 +115,12 @@ async def oauth_federated_google(
             return oauth_error(401, "invalid_client", "Use the public storefront client_id")
         if code == "invalid_grant":
             return oauth_error(400, "invalid_grant", "Google ID token invalid or email missing")
+        if code == "staff_federation_denied":
+            return oauth_error(
+                403,
+                "access_denied",
+                "Staff accounts cannot sign in via Telegram or Google; use the operational login.",
+            )
         return oauth_error(400, "invalid_grant", code)
     await session.commit()
     return JSONResponse(content=out)

--- a/tests/test_federated_staff_policy.py
+++ b/tests/test_federated_staff_policy.py
@@ -1,0 +1,18 @@
+"""Policy: storefront federation is only for customer accounts."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from src.auth.federated_login import _ensure_customer_for_federated_login
+
+
+def test_federated_allows_customer():
+    _ensure_customer_for_federated_login(SimpleNamespace(identity_kind="customer"))
+
+
+def test_federated_rejects_staff():
+    with pytest.raises(ValueError, match="staff_federation_denied"):
+        _ensure_customer_for_federated_login(SimpleNamespace(identity_kind="staff"))


### PR DESCRIPTION
Closes product policy from \docs/microservices/01-auth.md\: operational staff must not sign in via storefront federation.

**Behavior**
- \identity_kind=staff\ → \POST /oauth/federated/*\ returns **403** \ccess_denied\ (before linking a new \external_identity\ row).
- New helper \_ensure_customer_for_federated_login\ + tests.

**Docs**
- \DEPLOYMENT.md\: table of \[AUTH]\ variables.
- \README.md\: one-line policy note.

Related GitHub issues: storefront federation (#10/#11), identity policy (#12), env/docs (#9).

Made with [Cursor](https://cursor.com)