### PR TITLE
feat(obs): /metrics, X-Request-Id, auth_http_requests_total

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -136,6 +136,12 @@ curl http://localhost:8000/api/root/health # DB + Redis (200 or 503)
 
 Behind Nginx on port 80, `GET /health` proxies to liveness (`/health/live`).
 
+### Prometheus metrics
+
+`GET /metrics` exposes Prometheus text format (process metrics plus `auth_http_requests_total{method,status_code}`). Restrict scraping to internal networks or mTLS; do not expose publicly without auth.
+
+**Request correlation:** Send optional `X-Request-Id` (1–128 characters); the same value is returned on the response. If omitted, the service generates an ID. Application code can read the current value via `get_request_id()` in `src.middlewares.database`.
+
 ### Logs
 
 #### Docker:

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Microservice based on [Reei-dp/fastapi-template](https://github.com/Reei-dp/fast
 | `POST /oauth/federated/google` | JSON: `client_id` (public), `id_token` (Google ID token). **Requires** `[AUTH] GOOGLE_CLIENT_IDS`. |
 | `POST /oauth/federated/telegram` | JSON: Telegram Login widget fields + `client_id`. **Requires** `[AUTH] TELEGRAM_BOT_TOKEN`. |
 | `GET /health/live`, `GET /health/ready` | Liveness / readiness |
+| `GET /metrics` | Prometheus metrics (`auth_http_requests_total`, process stats) |
 | `/api/v1/users`, `/api/v1/users/{id}` | Admin: list/create/get/patch/delete (soft) users |
 | `/api/v1/users/{id}/roles`, `/api/v1/users/{id}/mfa` | Admin: replace/add roles; enable/disable MFA flags |
 | `/api/v1/roles`, `/api/v1/clients` | Admin: list roles; OAuth clients CRUD (secret shown once on create) |

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ cryptography~=44.0.0
 passlib[argon2]~=1.7.4
 argon2-cffi~=23.1.0
 email-validator~=2.2.0
+prometheus-client~=0.21.1

--- a/src/configuration/app.py
+++ b/src/configuration/app.py
@@ -2,8 +2,10 @@ import logging
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
+from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 from sqlalchemy import text
 from starlette.middleware.cors import CORSMiddleware
+from starlette.responses import Response
 
 from src.auth.bootstrap import run_bootstrap
 from src.database.core import async_session_maker
@@ -57,6 +59,15 @@ class App:
         async def health_ready(session: DbSession) -> dict:
             await session.execute(text("SELECT 1"))
             return {"status": "ready"}
+
+        @self._app.get(
+            "/metrics",
+            tags=["health"],
+            include_in_schema=False,
+            summary="Prometheus metrics",
+        )
+        async def prometheus_metrics() -> Response:
+            return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)
 
         self._register_routers()
 

--- a/src/metrics.py
+++ b/src/metrics.py
@@ -1,0 +1,9 @@
+"""Prometheus metrics for auth-service."""
+
+from prometheus_client import Counter
+
+HTTP_REQUESTS_TOTAL = Counter(
+    "auth_http_requests_total",
+    "Total HTTP requests handled",
+    ("method", "status_code"),
+)

--- a/src/middlewares/database.py
+++ b/src/middlewares/database.py
@@ -9,6 +9,19 @@ from starlette.requests import Request
 
 from src.database.core import async_session_maker
 from src.database.logging import SessionTracker
+from src.metrics import HTTP_REQUESTS_TOTAL
+
+
+def _resolve_request_id(request: Request) -> str:
+    """Prefer client X-Request-Id when present and sane; else generate one."""
+    raw = request.headers.get("x-request-id")
+    if not raw:
+        return str(uuid1())
+    rid = raw.strip()
+    if not rid or len(rid) > 128:
+        return str(uuid1())
+    return rid
+
 
 REQUEST_ID_CTX_KEY: Final[str] = "request_id"
 _request_id_ctx_var: ContextVar[str | None] = ContextVar(REQUEST_ID_CTX_KEY, default=None)
@@ -33,7 +46,7 @@ async def db_session_middleware(request: Request, call_next):
     Returns:
         Response from the next handler
     """
-    request_id = str(uuid1())
+    request_id = _resolve_request_id(request)
     ctx_token = _request_id_ctx_var.set(request_id)
 
     session: AsyncSession | None = None
@@ -46,7 +59,16 @@ async def db_session_middleware(request: Request, call_next):
             session, context="api_request_chime_service"
         )
 
-        response = await call_next(request)
+        try:
+            response = await call_next(request)
+        except Exception:
+            HTTP_REQUESTS_TOTAL.labels(method=request.method, status_code="500").inc()
+            raise
+
+        HTTP_REQUESTS_TOTAL.labels(
+            method=request.method, status_code=str(response.status_code)
+        ).inc()
+        response.headers["X-Request-Id"] = request_id
 
         if session.is_active:
             await session.commit()

--- a/tests/test_smoke_public.py
+++ b/tests/test_smoke_public.py
@@ -34,3 +34,22 @@ def test_jwks(client: TestClient):
 def test_oauth_authorize_stub(client: TestClient):
     r = client.get("/oauth/authorize")
     assert r.status_code == 400
+
+
+def test_metrics_prometheus(client: TestClient):
+    r = client.get("/metrics")
+    assert r.status_code == 200
+    assert "text/plain" in r.headers.get("content-type", "")
+    assert b"auth_http_requests_total" in r.content
+
+
+def test_x_request_id_echo_and_propagate(client: TestClient):
+    r = client.get("/health/live", headers={"X-Request-Id": "client-req-abc-1"})
+    assert r.status_code == 200
+    assert r.headers.get("x-request-id") == "client-req-abc-1"
+
+
+def test_x_request_id_generated_when_missing(client: TestClient):
+    r = client.get("/health/live")
+    assert r.status_code == 200
+    assert r.headers.get("x-request-id")


### PR DESCRIPTION
Implements observability from **#7**.

- **GET /metrics** — Prometheus text exposition (prometheus-client), including uth_http_requests_total{method,status_code} and default process metrics.
- **X-Request-Id** — optional inbound header (1–128 chars) echoed on responses; otherwise generated (UUID). Existing get_request_id() context unchanged.
- **Docs** — README endpoint table; DEPLOYMENT monitoring section (scrape network hygiene).

Tests: smoke tests for /metrics, header echo, and auto-generated id.

Made with [Cursor](https://cursor.com)