### PR TITLE
test(integration): expand OAuth/OIDC smoke coverage

### DIFF
--- a/tests/test_integration_db.py
+++ b/tests/test_integration_db.py
@@ -26,3 +26,63 @@ def test_oauth_token_invalid_client(client: TestClient):
     assert r.status_code == 401
     body = r.json()
     assert body.get("error") == "invalid_client"
+
+
+@pytest.mark.integration
+def test_oidc_discovery(client: TestClient):
+    r = client.get("/.well-known/openid-configuration")
+    assert r.status_code == 200
+    body = r.json()
+    assert "issuer" in body
+    assert "token_endpoint" in body
+    assert "userinfo_endpoint" in body
+    assert body["userinfo_endpoint"].endswith("/oauth/userinfo")
+
+
+@pytest.mark.integration
+def test_jwks(client: TestClient):
+    r = client.get("/.well-known/jwks.json")
+    assert r.status_code == 200
+    assert "keys" in r.json()
+    assert isinstance(r.json()["keys"], list)
+
+
+# Matches config.ini.example defaults after bootstrap (`_ensure_bootstrap_client`).
+_DEV_CLIENT_ID = "zhuchka-dev"
+_DEV_CLIENT_SECRET = "change-me-dev-only"
+
+
+@pytest.mark.integration
+def test_oauth_token_unsupported_grant_type(client: TestClient):
+    r = client.post(
+        "/oauth/token",
+        data={
+            "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+            "client_id": _DEV_CLIENT_ID,
+            "client_secret": _DEV_CLIENT_SECRET,
+        },
+    )
+    assert r.status_code == 400
+    assert r.json().get("error") == "unsupported_grant_type"
+
+
+@pytest.mark.integration
+def test_oauth_token_refresh_requires_refresh_token(client: TestClient):
+    r = client.post(
+        "/oauth/token",
+        data={
+            "grant_type": "refresh_token",
+            "client_id": _DEV_CLIENT_ID,
+            "client_secret": _DEV_CLIENT_SECRET,
+        },
+    )
+    assert r.status_code == 400
+    body = r.json()
+    assert body.get("error") == "invalid_request"
+
+
+@pytest.mark.integration
+def test_oauth_userinfo_requires_bearer(client: TestClient):
+    r = client.get("/oauth/userinfo")
+    assert r.status_code == 401
+    assert r.json().get("detail") == "missing_bearer"


### PR DESCRIPTION
Addresses **#6** — additional integration tests against Postgres (same CI bootstrap client as \config.ini.example\):

- \GET /.well-known/openid-configuration\ — issuer, token, userinfo endpoints
- \GET /.well-known/jwks.json\ — \keys\ array
- \POST /oauth/token\ — unsupported grant type (authenticated dev client)
- \POST /oauth/token\ — \efresh_token\ without \efresh_token\ form field
- \GET /oauth/userinfo\ — 401 without Bearer

Made with [Cursor](https://cursor.com)