### PR TITLE
feat(oauth): POST /oauth/introspect (RFC 7662)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Microservice based on [Reei-dp/fastapi-template](https://github.com/Reei-dp/fast
 | `GET /.well-known/jwks.json` | Public keys for JWT verification |
 | `POST /oauth/token` | Token (form body: `grant_type`, client auth Basic or `client_id`/`client_secret`) |
 | `POST /oauth/revoke` | Revoke refresh token |
+| `POST /oauth/introspect` | RFC 7662 token introspection (confidential client only; form: `token`, optional `token_type_hint`) |
 | `GET /oauth/userinfo` | OIDC userinfo (Bearer access token) |
 | `GET /oauth/authorize` | Stub until PKCE UI (returns `unsupported_response_type`) |
 | `POST /oauth/federated/google` | JSON: `client_id` (public), `id_token` (Google ID token). **Requires** `[AUTH] GOOGLE_CLIENT_IDS`. |

--- a/src/auth/oauth_logic.py
+++ b/src/auth/oauth_logic.py
@@ -13,7 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from src.auth.db_models import LoginAudit, OAuthClient, RefreshToken, User
-from src.auth.jwt_tokens import mint_access_token
+from src.auth.jwt_tokens import decode_access_token, mint_access_token
 from src.auth.passwords import verify_password, verify_secret
 from src.config import auth_cfg
 from src.database.core import async_session_maker
@@ -373,3 +373,72 @@ async def revoke_refresh_token(session: AsyncSession, token: str | None) -> None
     row = r.scalar_one_or_none()
     if row and not row.revoked_at:
         row.revoked_at = datetime.now(tz=UTC)
+
+
+async def introspect_access_token_string(token: str) -> dict[str, Any]:
+    """RFC 7662-style introspection for RS256 access JWTs issued by this server."""
+    try:
+        claims = decode_access_token(token)
+    except Exception:
+        return {"active": False}
+    if claims.get("token_use") != "access":
+        return {"active": False}
+    sub = claims.get("sub")
+    if not sub:
+        return {"active": False}
+    out: dict[str, Any] = {
+        "active": True,
+        "token_type": "Bearer",
+        "scope": str(claims.get("scope") or ""),
+        "client_id": str(claims.get("client_id") or ""),
+        "sub": str(sub),
+    }
+    exp = claims.get("exp")
+    iat = claims.get("iat")
+    if exp is not None:
+        out["exp"] = int(exp)
+    if iat is not None:
+        out["iat"] = int(iat)
+    return out
+
+
+async def introspect_refresh_token_string(session: AsyncSession, raw: str) -> dict[str, Any]:
+    h = _hash_refresh(raw)
+    r = await session.execute(
+        select(RefreshToken)
+        .options(selectinload(RefreshToken.client))
+        .where(RefreshToken.token_hash == h)
+    )
+    row = r.scalar_one_or_none()
+    if not row or row.revoked_at or row.expires_at < datetime.now(tz=UTC):
+        return {"active": False}
+    oc = row.client
+    cid = oc.client_id if oc else ""
+    out: dict[str, Any] = {
+        "active": True,
+        "token_type": "refresh_token",
+        "scope": row.scope or "",
+        "client_id": cid,
+        "sub": str(row.user_id) if row.user_id else f"client:{cid}",
+        "exp": int(row.expires_at.timestamp()),
+    }
+    return out
+
+
+async def introspect_token(
+    session: AsyncSession,
+    *,
+    token: str,
+    token_type_hint: str | None,
+) -> dict[str, Any]:
+    """Return introspection JSON (active + metadata). Caller must authenticate a confidential client."""
+    hint = (token_type_hint or "").strip().lower()
+    if hint == "refresh_token":
+        return await introspect_refresh_token_string(session, token)
+    if hint == "access_token":
+        return await introspect_access_token_string(token)
+    if token.count(".") == 2:
+        r = await introspect_access_token_string(token)
+        if r.get("active"):
+            return r
+    return await introspect_refresh_token_string(session, token)

--- a/src/openapi_config.py
+++ b/src/openapi_config.py
@@ -9,7 +9,7 @@ OPENAPI_TAGS: list[dict[str, str]] = [
     {"name": "health", "description": "Liveness and readiness probes."},
     {
         "name": "oauth",
-        "description": "OAuth2 token endpoint, revoke, OIDC discovery, JWKS.",
+        "description": "OAuth2 token endpoint, revoke, introspection (RFC 7662), OIDC discovery, JWKS.",
     },
     {"name": "oidc", "description": "OIDC discovery document and JWKS (same router as oauth)."},
     {

--- a/src/routers/oauth/router.py
+++ b/src/routers/oauth/router.py
@@ -17,6 +17,7 @@ from src.auth.oauth_logic import (
     grant_client_credentials,
     grant_password,
     grant_refresh_token,
+    introspect_token,
     revoke_refresh_token,
 )
 from src.config import auth_cfg
@@ -38,6 +39,7 @@ async def openid_configuration() -> dict:
         "authorization_endpoint": f"{base}/oauth/authorize",
         "token_endpoint": f"{base}/oauth/token",
         "userinfo_endpoint": f"{base}/oauth/userinfo",
+        "introspection_endpoint": f"{base}/oauth/introspect",
         "jwks_uri": f"{base}/.well-known/jwks.json",
         "response_types_supported": ["code"],
         "grant_types_supported": [
@@ -140,6 +142,37 @@ async def oauth_revoke(
 ) -> Response:
     await revoke_refresh_token(session, token)
     return Response(status_code=200)
+
+
+@router.post("/oauth/introspect", include_in_schema=True)
+async def oauth_introspect(
+    session: DbSession,
+    token: str | None = Form(None),
+    token_type_hint: str | None = Form(None),
+    client_id: str | None = Form(None),
+    client_secret: str | None = Form(None),
+    client_basic: HTTPBasicCredentials | None = Depends(HTTPBasic(auto_error=False)),
+) -> JSONResponse:
+    """RFC 7662 token introspection. Requires a **confidential** OAuth client (Basic or form auth)."""
+    if not token:
+        return oauth_error(400, "invalid_request", "token is required")
+    client = await authenticate_client(
+        session,
+        client_id=client_id,
+        client_secret=client_secret,
+        basic_user=client_basic.username if client_basic else None,
+        basic_password=client_basic.password if client_basic else None,
+    )
+    if not client:
+        return oauth_error(401, "invalid_client", "Client authentication failed")
+    if client.is_public:
+        return oauth_error(
+            401,
+            "invalid_client",
+            "Token introspection requires a confidential OAuth client",
+        )
+    body = await introspect_token(session, token=token, token_type_hint=token_type_hint)
+    return JSONResponse(content=body)
 
 
 @router.get("/oauth/userinfo", include_in_schema=True)

--- a/tests/test_integration_db.py
+++ b/tests/test_integration_db.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 import pytest
 from starlette.testclient import TestClient
 
+# Matches config.ini.example defaults after bootstrap (`_ensure_bootstrap_client`).
+_DEV_CLIENT_ID = "zhuchka-dev"
+_DEV_CLIENT_SECRET = "change-me-dev-only"
+
 
 @pytest.mark.integration
 def test_health_ready(client: TestClient):
@@ -37,6 +41,7 @@ def test_oidc_discovery(client: TestClient):
     assert "token_endpoint" in body
     assert "userinfo_endpoint" in body
     assert body["userinfo_endpoint"].endswith("/oauth/userinfo")
+    assert body.get("introspection_endpoint", "").endswith("/oauth/introspect")
 
 
 @pytest.mark.integration
@@ -45,11 +50,6 @@ def test_jwks(client: TestClient):
     assert r.status_code == 200
     assert "keys" in r.json()
     assert isinstance(r.json()["keys"], list)
-
-
-# Matches config.ini.example defaults after bootstrap (`_ensure_bootstrap_client`).
-_DEV_CLIENT_ID = "zhuchka-dev"
-_DEV_CLIENT_SECRET = "change-me-dev-only"
 
 
 @pytest.mark.integration
@@ -86,3 +86,78 @@ def test_oauth_userinfo_requires_bearer(client: TestClient):
     r = client.get("/oauth/userinfo")
     assert r.status_code == 401
     assert r.json().get("detail") == "missing_bearer"
+
+
+@pytest.mark.integration
+def test_oauth_introspect_requires_token(client: TestClient):
+    r = client.post(
+        "/oauth/introspect",
+        data={
+            "client_id": _DEV_CLIENT_ID,
+            "client_secret": _DEV_CLIENT_SECRET,
+        },
+    )
+    assert r.status_code == 400
+    assert r.json().get("error") == "invalid_request"
+
+
+@pytest.mark.integration
+def test_oauth_introspect_invalid_client(client: TestClient):
+    r = client.post(
+        "/oauth/introspect",
+        data={"token": "x", "client_id": "no-such", "client_secret": "nope"},
+    )
+    assert r.status_code == 401
+    assert r.json().get("error") == "invalid_client"
+
+
+@pytest.mark.integration
+def test_oauth_introspect_rejects_public_client(client: TestClient):
+    r = client.post(
+        "/oauth/introspect",
+        data={"token": "x", "client_id": "zhuchka-market-web"},
+    )
+    assert r.status_code == 401
+
+
+@pytest.mark.integration
+def test_oauth_introspect_client_credentials_access_token(client: TestClient):
+    tr = client.post(
+        "/oauth/token",
+        data={
+            "grant_type": "client_credentials",
+            "client_id": _DEV_CLIENT_ID,
+            "client_secret": _DEV_CLIENT_SECRET,
+        },
+    )
+    assert tr.status_code == 200
+    at = tr.json()["access_token"]
+    ir = client.post(
+        "/oauth/introspect",
+        data={
+            "token": at,
+            "token_type_hint": "access_token",
+            "client_id": _DEV_CLIENT_ID,
+            "client_secret": _DEV_CLIENT_SECRET,
+        },
+    )
+    assert ir.status_code == 200
+    body = ir.json()
+    assert body.get("active") is True
+    assert body.get("sub") == f"client:{_DEV_CLIENT_ID}"
+    assert body.get("token_type") == "Bearer"
+    assert "exp" in body
+
+
+@pytest.mark.integration
+def test_oauth_introspect_unknown_token_inactive(client: TestClient):
+    ir = client.post(
+        "/oauth/introspect",
+        data={
+            "token": "not-a-valid-token",
+            "client_id": _DEV_CLIENT_ID,
+            "client_secret": _DEV_CLIENT_SECRET,
+        },
+    )
+    assert ir.status_code == 200
+    assert ir.json() == {"active": False}


### PR DESCRIPTION
## Summary
Implements **OAuth 2.0 Token Introspection** ([RFC 7662](https://datatracker.ietf.org/doc/html/rfc7662)) for resource servers that prefer introspection over local JWKS validation.

## Behavior
- \POST /oauth/introspect\ — \pplication/x-www-form-urlencoded\: \	oken\ (required), optional \	oken_type_hint\ (\ccess_token\ | \efresh_token\).
- **Client authentication required** — same as token endpoint (Basic or \client_id\ + \client_secret\). **Public OAuth clients are rejected** (401 \invalid_client\).
- **Access tokens**: validate RS256 JWT issued by this AS (\	oken_use=access\), return \ctive\, \sub\, \scope\, \client_id\, \exp\, \iat\, \	oken_type\.
- **Refresh tokens**: lookup hashed row in DB; \ctive\ false if missing, revoked, or expired.
- OIDC discovery includes \introspection_endpoint\.

## Tests
Integration tests cover client_credentials → introspect, missing token, bad client, public client, unknown token.

Closes #14

Made with [Cursor](https://cursor.com)