### PR TITLE
feat(bootstrap): support.read / support.write on dev OAuth client

### DIFF
--- a/src/auth/bootstrap.py
+++ b/src/auth/bootstrap.py
@@ -42,7 +42,14 @@ async def _ensure_bootstrap_client(session: AsyncSession) -> None:
                 "client_credentials",
                 "password",
             ],
-            allowed_scopes=["openid", "profile", "email", "admin"],
+            allowed_scopes=[
+                "openid",
+                "profile",
+                "email",
+                "admin",
+                "support.read",
+                "support.write",
+            ],
             allow_password_grant=True,
         )
     )


### PR DESCRIPTION
Adds \support.read\ and \support.write\ to the bootstrap OAuth client \llowed_scopes\ so tokens can be minted for Directory staff routes (ZhuchkaKeyboards_directory PR).

Related: ZhuchkaKeyboards_directory#8

Made with [Cursor](https://cursor.com)